### PR TITLE
Update checkout_index_index.xml

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -23,9 +23,12 @@
                                                         <item name="renders" xsi:type="array">
                                                             <!-- merge payment method renders here -->
                                                             <item name="children" xsi:type="array">
-                                                                <item name="santander_invoice" xsi:type="array">
+                                                                <item name="santander-payments" xsi:type="array">
                                                                     <item name="component" xsi:type="string">SantanderPaymentSolutions_SantanderPayments/js/view/payment/santander</item>
                                                                     <item name="methods" xsi:type="array">
+                                                                        <item name="santander_invoice" xsi:type="array">
+                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
+                                                                        </item>
                                                                         <item name="santander_hire" xsi:type="array">
                                                                             <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
                                                                         </item>


### PR DESCRIPTION
Issue: #2 
santander_invoice is not properly added to XML layout, therefore if Santander Ratenkauf is not active in Admin Panel, js component will not load on the frontend in the Checkout and Santander Rechnungskauf will not be visible.

Actual:
In admin panel, you can enable Santander Ratenkauf only and have it display properly on the frontend.

In admin panel, you can enable both Santander Ratenkauf and Santander Rechnungskauf and have them both visible on the frontend.

In admin panel, you can not enable Santander Rechnungskauf only. It won't be visible on the frontend.

Solution:
Update XML to include both payment methods properly.